### PR TITLE
Update Knot Atlas and KnotInfo entries

### DIFF
--- a/_databases/knot-atlas.md
+++ b/_databases/knot-atlas.md
@@ -2,7 +2,7 @@
 id: knot-atlas
 location: http://katlas.org/wiki/Main_Page
 authors:
-- name: Kim Morrsion
+- name: Kim Morrison
   homepage: https://tqft.net/
 - name: Dror Bar-Natan
   homepage: https://www.math.toronto.edu/drorbn/

--- a/_databases/knot-invariants.md
+++ b/_databases/knot-invariants.md
@@ -2,16 +2,16 @@
 authors:
 - homepage: https://livingst.pages.iu.edu
   name: Charles Livingston
-- homepage: https://people.vcu.edu/~moorea14/
+- homepage: https://allisonhmoore.github.io
   name: Allison H. Moore
 id: knot-invariants
-location: http://www.indiana.edu/~knotinfo/
+location: https://knotinfo.org
 area:
 - geometric topology
 tags:
 - knot invariant
 - knot theory
-title: Table of Knot Invariants
+title: 'KnotInfo: Table of Knot Invariants'
 searchable: true
 badges:
 - collaborative


### PR DESCRIPTION
KnotInfo has moved to a new URL; I also corrected the name and the URL for contributor Allison Moore. In addition, I fixed a typo in Kim Morrison's name (contributor to the Knot Atlas).