### PR TITLE
Adds Erdős Problems repository

### DIFF
--- a/_databases/erdosproblems.md
+++ b/_databases/erdosproblems.md
@@ -1,0 +1,18 @@
+id: erdosproblems
+location: "https://www.erdosproblems.com/"
+title: "Erdős Problems database"
+ascii_name: "Erdos Problems database"
+area:
+  - combinatorics
+  - number theory
+license: "Apache-2.0"
+num_objects: 992
+is_compressed: false
+code_location: "https://github.com/teorth/erdosproblems"
+start_date: 2025
+accessible: true
+completeness: "Contains 992 mathematical problems inspired by Paul Erdős."
+short_description: "A collaborative database of mathematical problems inspired by Paul Erdős."
+contact_email: erdosproblemsonline@gmail.com
+references:
+  - url: "https://terrytao.wordpress.com/2025/08/31/a-crowdsourced-project-to-link-up-erdosproblems-com-to-the-oeis/"


### PR DESCRIPTION
Adds the [Erdõs Problem database](https://www.erdosproblems.com/). More information about it is available at [Terence Tao's blog](https://terrytao.wordpress.com/2025/08/31/a-crowdsourced-project-to-link-up-erdosproblems-com-to-the-oeis/).