### PR TITLE
Add woollymathematics database entry

### DIFF
--- a/_databases/woollymathematics.md
+++ b/_databases/woollymathematics.md
@@ -1,0 +1,23 @@
+id: woollymathematics
+location: "https://woollymathematics.com/"
+title: "Woolly Mathematics"
+ascii_name: "Woolly Mathematics"
+area:
+  - history and overview
+  - general mathematics
+  - mathematics education
+  - combinatorics
+  - number theory
+  - linear algebra
+num_objects: 18783
+is_compressed: false
+start_date: 2023
+accessible: true
+completeness: "Contains 18,783 problems from The Educational Times (1848–1915) and their solutions."
+short_description: "A searchable database of 19th–20th century mathematical problems from The Educational Times and Mathematical Questions."
+contact_email: "woollymathematics@gmail.com"
+references:
+  - url: "https://woollymathematics.com/about"
+  - url: "https://woollymathematics.com/faq"
+  - url: "https://old.maa.org/press/periodicals/convergence/the-educational-times-database-building-a-database-of-etmq-problems-and-solutions-2010s"
+  - doi: "10.1007/s00283-025-10467-1"


### PR DESCRIPTION
Adds [woollymathematics](https://woollymathematics.com/), a searchable database of 19th–20th century mathematical problems from The Educational Times and Mathematical Questions.