### PR TITLE
Fix stale URLs and typo in database entries

### DIFF
--- a/_databases/ame-states.md
+++ b/_databases/ame-states.md
@@ -14,4 +14,4 @@ area:
 
 ---
 
-able on the existence of absolutely maximally entangled states (AME) of n parties with D levels each.
+Table on the existence of absolutely maximally entangled states (AME) of n parties with D levels each.

--- a/_databases/chiral-polytopes-small-almost.md
+++ b/_databases/chiral-polytopes-small-almost.md
@@ -7,7 +7,7 @@ authors:
 - homepage: https://www.matem.unam.mx/fsd/hubard
   name: Isabel Hubard
 id: chiral-polytopes-small-almost
-location: http://homepages.ulb.ac.be/~dleemans/CHIRAL/index.html
+location: https://leemans.dimitri.web.ulb.be/CHIRAL/index.html
 num_objects: 19212
 references:
 - web: https://amc-journal.eu/index.php/amc/article/view/204/192

--- a/_databases/pi-base.md
+++ b/_databases/pi-base.md
@@ -9,7 +9,7 @@ location: https://topology.pi-base.org
 title: "\u03C0-Base"
 ascii_name: "pi-base"
 license: "CC BY-SA 4.0"
-code_location: "https://github.org/pi-base/web"
+code_location: "https://github.com/pi-base/web"
 start_date: 2014
 accessible: true
 searchable: true

--- a/_databases/quadri-figures.md
+++ b/_databases/quadri-figures.md
@@ -3,7 +3,7 @@ authors:
 - name: Chris van Tienhoven
   homepage: https://chrisvantienhoven.nl/
 id: quadri-figures
-location: https://chrisvantienhoven.nl/mathematics/encyclopedia
+location: https://www.chrisvantienhoven.nl/epg/n-geometry/quadri-figures/
 num_objects: 300
 area:
 - metric geometry

--- a/_databases/subgroup-lattices-finite-almost.md
+++ b/_databases/subgroup-lattices-finite-almost.md
@@ -4,7 +4,7 @@ authors:
   name: Dimitri Leemans
 - name: Thomas Connor
 id: subgroup-lattices-finite-almost
-location: http://homepages.ulb.ac.be/~dleemans/atlaslat/
+location: https://leemans.dimitri.web.ulb.be/atlaslat/
 references:
 - doi: 10.26493/1855-3974.455.422
 area:


### PR DESCRIPTION
Small fixes across five database entries: three for authors who moved their homepages, URL typo in `pi-base` (`github.org`) and a missing character in the description in the last one.