### PR TITLE
fix: correct pi-base code repository URL

### DIFF
--- a/_databases/pi-base.md
+++ b/_databases/pi-base.md
@@ -9,7 +9,7 @@ location: https://topology.pi-base.org
 title: "\u03C0-Base"
 ascii_name: "pi-base"
 license: "CC BY-SA 4.0"
-code_location: "https://github.org/pi-base/web"
+code_location: "https://github.com/pi-base/web"
 start_date: 2014
 accessible: true
 searchable: true


### PR DESCRIPTION
## Summary
The pi-base entry linked its code repository to `github.org/pi-base/web` instead of `github.com/pi-base/web`.

## Root cause
Typo in the `code_location` field (`github.org` is not GitHub's domain).

## Why this fix is correct
The pi-base source repo lives at https://github.com/pi-base/web; the dataset page should link there.


Made with [Cursor](https://cursor.com)