### PR TITLE
fix: restore missing word in AME states description

### DIFF
--- a/_databases/ame-states.md
+++ b/_databases/ame-states.md
@@ -14,4 +14,4 @@ area:
 
 ---
 
-able on the existence of absolutely maximally entangled states (AME) of n parties with D levels each.
+Table on the existence of absolutely maximally entangled states (AME) of n parties with D levels each.


### PR DESCRIPTION
## Summary
The AME states dataset page description began with "able on the existence..." instead of "Table on the existence...".

## Root cause
The leading "T" of "Table" was dropped from the description text.

## Why this fix is correct
The entry title is "Table of AME states"; the description should read "Table on the existence of absolutely maximally entangled states...".


Made with [Cursor](https://cursor.com)