### PR TITLE
fix: update CHIRAL dataset location URL

### DIFF
--- a/_databases/chiral-polytopes-small-almost.md
+++ b/_databases/chiral-polytopes-small-almost.md
@@ -7,7 +7,7 @@ authors:
 - homepage: https://www.matem.unam.mx/fsd/hubard
   name: Isabel Hubard
 id: chiral-polytopes-small-almost
-location: http://homepages.ulb.ac.be/~dleemans/CHIRAL/index.html
+location: https://leemans.dimitri.web.ulb.be/CHIRAL/index.html
 num_objects: 19212
 references:
 - web: https://amc-journal.eu/index.php/amc/article/view/204/192


### PR DESCRIPTION
## Summary
The chiral polytopes entry still pointed at Dimitri Leemans's old `homepages.ulb.ac.be` URL.

## Root cause
Author homepage moved; the dataset `location` field was never updated.

## Why this fix is correct
The CHIRAL data now lives at https://leemans.dimitri.web.ulb.be/CHIRAL/index.html.


Made with [Cursor](https://cursor.com)