### PR TITLE
fix: update quadri-figures dataset location URL

### DIFF
--- a/_databases/quadri-figures.md
+++ b/_databases/quadri-figures.md
@@ -3,7 +3,7 @@ authors:
 - name: Chris van Tienhoven
   homepage: https://chrisvantienhoven.nl/
 id: quadri-figures
-location: https://chrisvantienhoven.nl/mathematics/encyclopedia
+location: https://www.chrisvantienhoven.nl/epg/n-geometry/quadri-figures/
 num_objects: 300
 area:
 - metric geometry


### PR DESCRIPTION
## Summary
The quadri-figures entry still linked to an old encyclopedia path on chrisvantienhoven.nl.

## Root cause
The dataset moved to a new URL under `/epg/n-geometry/quadri-figures/`.

## Why this fix is correct
The updated location matches the author's current site structure.


Made with [Cursor](https://cursor.com)