### PR TITLE
fix: update subgroup lattices atlas location URL

### DIFF
--- a/_databases/subgroup-lattices-finite-almost.md
+++ b/_databases/subgroup-lattices-finite-almost.md
@@ -4,7 +4,7 @@ authors:
   name: Dimitri Leemans
 - name: Thomas Connor
 id: subgroup-lattices-finite-almost
-location: http://homepages.ulb.ac.be/~dleemans/atlaslat/
+location: https://leemans.dimitri.web.ulb.be/atlaslat/
 references:
 - doi: 10.26493/1855-3974.455.422
 area:


### PR DESCRIPTION
## Summary
The subgroup-lattices entry still pointed at Dimitri Leemans's old `homepages.ulb.ac.be` atlas URL.

## Root cause
Author homepage migration; the `location` field was never updated.

## Why this fix is correct
The atlas now lives at https://leemans.dimitri.web.ulb.be/atlaslat/.


Made with [Cursor](https://cursor.com)