### PR TITLE
Show each dataset's git last-modified date as its "Updated:" date

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,71 @@
+# Builds the site with Jekyll and publishes it to GitHub Pages.
+#
+# This replaces GitHub's built-in ("legacy") Pages build. The legacy builder
+# only loads plugins on GitHub's allow-list, and jekyll-last-modified-at (which
+# gives every dataset page an accurate "Updated:" date from its last git commit)
+# is not on that list. The only way to use it is to build the site ourselves
+# here and deploy the result.
+#
+# ONE-TIME SETUP required in the repo settings once this file is on `live`:
+#   Settings -> Pages -> "Build and deployment" -> Source: "GitHub Actions".
+# Until that switch is made, the legacy build keeps running and the deploy job
+# below cannot publish.
+name: Deploy site to GitHub Pages
+
+on:
+  # `live` is the branch GitHub Pages deploys from, so a push to it (e.g.
+  # promoting `main` -> `live`) should rebuild and republish the site.
+  push:
+    branches:
+      - live
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Permissions needed for actions/deploy-pages to publish.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one deployment at a time and let an in-progress deploy finish rather
+# than cancelling it (avoids publishing a half-built site).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history (not a shallow clone) so jekyll-last-modified-at can
+          # read each file's last commit date. With the default fetch-depth of
+          # 1, every "Updated:" date would collapse to the checkout time again.
+          fetch-depth: 0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem "minimal-mistakes-jekyll"
 group :jekyll_plugins do
   gem "github-pages"
   gem "jekyll-include-cache"
+  gem "jekyll-last-modified-at"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ plugins:
   - jekyll-feed
   - jemoji
   - jekyll-include-cache
+  - jekyll-last-modified-at
 
 title: MathBases
 description: Of, by, and for mathematical databases


### PR DESCRIPTION
Fixes #88.

## Problem

The "Updated:" date at the bottom of every page was the site's **deploy time** — identical across all pages — rather than when that page actually changed. The minimal-mistakes theme already renders `page.last_modified_at` as the "Updated:" date, but nothing was populating that variable with a real per-file date, so it fell back to the build/checkout time.

## Fix

- Add the [`jekyll-last-modified-at`](https://github.com/gjtorikian/jekyll-last-modified-at) plugin (the one linked in the issue). It sets `page.last_modified_at` from each file's **last git commit** (`git log -1 --format=%ct`), falling back to file mtime for uncommitted files. Because the theme already renders that variable, **no layout change is needed**.
- Add a GitHub Actions workflow (`.github/workflows/pages.yml`) to build and deploy the site. This is necessary because `jekyll-last-modified-at` is **not on GitHub Pages' allow-list**, so it is silently ignored by the built-in ("legacy") Pages builder the site currently uses. The workflow builds the site ourselves and deploys the result. It:
  - triggers on pushes to `live` (the current production branch), preserving the existing `main` → `live` promotion gate;
  - checks out with `fetch-depth: 0` so the plugin can read git history (a shallow clone would collapse every date back to the checkout time).

`Gemfile.lock` is gitignored, so there is nothing to commit for it; CI resolves the `Gemfile` fresh (the plugin's only dependency is `jekyll`, already satisfied).

## ⚠️ One-time manual step required to activate

After this reaches `live`, a repo admin must switch **Settings → Pages → Build and deployment → Source** from "Deploy from a branch" to **"GitHub Actions"**. Until then the legacy build keeps running (it harmlessly ignores the plugin — nothing breaks, dates just stay as they are). The change is reversible: if the Actions build ever misbehaves, switch the source back to the `live` branch.

## Verification

Built locally with the plugin; the rendered "Updated:" dates now match each file's git history instead of one uniform date:

| page | git last-commit | rendered "Updated:" |
|---|---|---|
| `local-fields` | 2025-05-09 | May 9, 2025 |
| `lmfdb` | 2025-05-30 | May 30, 2025 |
| `boolean-zoo` | 2025-05-09 | May 9, 2025 |

All dataset pages build cleanly; dates now span the real edit history (2025-04 → 2026-07) rather than collapsing to the deploy date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
