### PR TITLE
Exclude vendor/ so the GitHub Actions build succeeds

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,17 @@ exclude:
   - "DATA.md"
   - "template.md"
   - "split_data.py"
+  # Jekyll's default excludes (a custom `exclude:` replaces the defaults rather
+  # than merging, so they must be restated). Without vendor/bundle/ here, the
+  # Actions build tries to render files inside the bundler-installed gems and
+  # fails.
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
 
 defaults: # setting default variables for pages, e.g., layout
   - scope:


### PR DESCRIPTION
Follow-up to #153 — fixes the failing GitHub Actions build ([run](https://github.com/MathBases/MathBases/actions/runs/29367874804)).

## Problem

The Actions runner installs gems into `vendor/bundle/` inside the working directory. Jekyll then tried to render a file *inside* one of those gems — Jekyll's own post template, whose front matter carries a placeholder `<%= ... %>` date — and aborted:

```
Error: could not read file .../vendor/bundle/ruby/3.3.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb:
Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': ... does not have a valid date in the YAML front matter.
```

Jekyll's **default** `exclude` already covers `vendor/bundle/`, but a custom `exclude:` **replaces** the defaults rather than merging — so this site's three-item `exclude:` silently dropped them. It never showed locally because gems live outside the source tree there.

## Fix

Restate Jekyll's default excludes alongside the site's custom entries.

## Verification

Reproduced the exact CI error locally by planting the offending gem template under `vendor/bundle/`:

- old 3-item `exclude:` → same "Invalid date" failure as CI;
- with this fix → builds cleanly.

Also confirmed the rest of the production path is unaffected: the `github-pages` gem's hook still auto-loads `jekyll-remote-theme` (so `remote_theme` works), it does not override this custom `exclude`, and `jekyll-last-modified-at` still runs under `safe: true` because it's required via the `:jekyll_plugins` bundler group at startup.

Needs promoting `main` → `live` again to re-run the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
