### PR TITLE
Set repository/url so the Actions build resolves site.github

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,11 @@ plugins:
 
 title: MathBases
 description: Of, by, and for mathematical databases
+url: "https://mathbases.org"
+# name-with-owner of the production repo. jekyll-github-metadata (loaded by the
+# github-pages gem) needs this to resolve site.github.*; GitHub's legacy builder
+# sets it automatically via PAGES_REPO_NWO, but our Actions build must state it.
+repository: "MathBases/MathBases"
 exclude:
   - "DATA.md"
   - "template.md"


### PR DESCRIPTION
Follow-up to #153/#155 — fixes the next GitHub Actions build failure ([run](https://github.com/MathBases/MathBases/actions/runs/29369689392)). Good news: the vendor fix worked — the build now loads the remote theme and generates the feed before this error.

## Problem

```
Liquid Exception: No repo name found. Specify using PAGES_REPO_NWO environment
variables, 'repository' in your configuration, or set up an 'origin' git remote
pointing to your github.com repository. in /_layouts/single.html
```

The theme's `_includes/seo.html` evaluates `site.github.url`, which makes `jekyll-github-metadata` (bundled with the `github-pages` gem) resolve the repo's name-with-owner. GitHub's legacy builder supplies that automatically via `PAGES_REPO_NWO`; our Actions build has neither that nor a usable `origin` remote (git rejects the runner's checkout dir as dubious-ownership), so the lookup is fatal.

## Fix (config only)

- `repository: MathBases/MathBases` — gives the plugin the NWO (the exact remedy the error message names).
- `url: https://mathbases.org` — so SEO/feed/sitemap absolute URLs use the real domain rather than github-metadata's `github.io` fallback.

No API token is needed: with the NWO known, `site.github.*` fields degrade gracefully to nil without auth (`.render || {}` in the plugin), so nothing else raises.

Verified the local build still succeeds (168 pages, "Updated:" dates still per-file-correct, valid YAML). Not caught earlier because the local build doesn't load the github-pages plugins.

After merge, promote `main` → `live` to re-run the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
