### PR TITLE
Add "filter by area" control to the index table (#86)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -82,29 +82,49 @@ h1, h2 {
 /* "Filter by area" control on the index page (issue #86) */
 /* Keep the [hidden] attribute working despite the display rules below
    (a class's `display` would otherwise override [hidden]'s display:none). */
-.area-filter[hidden],
-.area-filter-menu[hidden] { display: none; }
-.area-filter {
-  position: relative;
+.area-filter-control[hidden],
+.area-filter-menu[hidden],
+.area-filter-chips-row[hidden] { display: none; }
+
+/* JS moves the filter control + the DataTables search box into this toolbar,
+   right-aligned on the title line so nothing below shifts down. */
+.index-toolbar {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   align-items: center;
   gap: 8px;
-  margin: 0 0 12px 0;
-  z-index: 3;
 }
+.index-toolbar .dataTables_filter { margin: 0; text-align: right; }
+/* Pin both controls to the same height so they line up (the theme's own input
+   height is inconsistent across renders). */
+.index-toolbar .dataTables_filter input { height: 34px; box-sizing: border-box; margin-bottom: 8px; }
+
+.area-filter-control { position: relative; }
 .area-filter-toggle {
   font: inherit;
   cursor: pointer;
-  padding: 5px 12px;
+  height: 34px;          /* match the search input */
+  margin: 0 0 8px 0;     /* match the search input's bottom margin */
+  padding: 0 12px;
   color: #0a1045;
   background: #FBE6C5;
   border: 1px solid #0a1045;
   border-radius: 4px;
+  box-sizing: border-box;
+  white-space: nowrap;
 }
 .area-filter-toggle.has-selection { background: #ffca76; }
 .area-filter-caret { font-size: 0.8em; }
 
+/* Selected areas, on their own row below the toolbar. */
+.area-filter-chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 8px 0;
+}
 .area-filter-chips {
   display: inline-flex;
   flex-wrap: wrap;
@@ -146,10 +166,12 @@ h1, h2 {
   padding: 0 4px;
 }
 
+/* Right-aligned dropdown (the control sits at the top-right), capped so it
+   never runs off either edge of the viewport. */
 .area-filter-menu {
   position: absolute;
   top: 100%;
-  left: 0;
+  right: 0;
   margin-top: 4px;
   z-index: 10;
   background: #fffcf7;
@@ -158,10 +180,13 @@ h1, h2 {
   box-shadow: 0 4px 14px rgba(10, 16, 69, 0.25);
   padding: 6px;
   max-height: 340px;
+  overflow-x: hidden;
   overflow-y: auto;
   display: grid;
-  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  grid-template-columns: 1fr 1fr;
   gap: 1px 8px;
+  width: 660px;
+  max-width: calc(100vw - 24px);
 }
 .area-filter-opt {
   display: flex;
@@ -181,6 +206,17 @@ h1, h2 {
   font-size: 0.85em;
   font-variant-numeric: tabular-nums;
 }
+
+/* Narrow screens: the title wraps and there's no room to tuck the toolbar up
+   beside it, so let it flow below the title and stack the controls/menu. */
+@media (max-width: 800px) {
+  #imdb_table_wrapper { margin-top: 0; }
+  .index-toolbar { justify-content: flex-start; }
+}
 @media (max-width: 640px) {
-  .area-filter-menu { grid-template-columns: 1fr; }
+  .area-filter-menu {
+    grid-template-columns: 1fr;
+    left: 0;
+    right: auto;
+  }
 }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -78,3 +78,109 @@ h1, h2 {
 .datatable a, .datatable a:visited, page__content a, page__content a:visited {
   color: #3743a9;
 }
+
+/* "Filter by area" control on the index page (issue #86) */
+/* Keep the [hidden] attribute working despite the display rules below
+   (a class's `display` would otherwise override [hidden]'s display:none). */
+.area-filter[hidden],
+.area-filter-menu[hidden] { display: none; }
+.area-filter {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px 0;
+  z-index: 3;
+}
+.area-filter-toggle {
+  font: inherit;
+  cursor: pointer;
+  padding: 5px 12px;
+  color: #0a1045;
+  background: #FBE6C5;
+  border: 1px solid #0a1045;
+  border-radius: 4px;
+}
+.area-filter-toggle.has-selection { background: #ffca76; }
+.area-filter-caret { font-size: 0.8em; }
+
+.area-filter-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.area-filter-chip {
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px 3px 10px;
+  color: #0a1045;
+  background: #ffca76;
+  border: 1px solid #0a1045;
+  border-radius: 12px;
+  line-height: 1.3;
+}
+.area-filter-chip-x {
+  font-weight: bold;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.area-filter-chip:hover .area-filter-chip-x {
+  background: #0a1045;
+  color: #ffca76;
+}
+.area-filter-clear {
+  font: inherit;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: #3743a9;
+  text-decoration: underline;
+  padding: 0 4px;
+}
+
+.area-filter-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  z-index: 10;
+  background: #fffcf7;
+  border: 1px solid #0a1045;
+  border-radius: 4px;
+  box-shadow: 0 4px 14px rgba(10, 16, 69, 0.25);
+  padding: 6px;
+  max-height: 340px;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 1px 8px;
+}
+.area-filter-opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 4px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.area-filter-opt:hover { background: #FBE6C5; }
+.area-filter-opt input { margin: 0; }
+.area-filter-name { flex: 1 1 auto; }
+.area-filter-cnt {
+  color: #777;
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 640px) {
+  .area-filter-menu { grid-template-columns: 1fr; }
+}

--- a/index.md
+++ b/index.md
@@ -2,7 +2,29 @@
 layout: plain
 ---
 <h1 class="smallcaps" id="imdb_title">Index of Mathematical DataBases</h1>
-<table class="display datatable" data-order-columns="[1]">
+<div id="area-filter" class="area-filter" hidden>
+    <button type="button" id="area-filter-toggle" class="area-filter-toggle" aria-expanded="false" aria-controls="area-filter-menu">
+        Filter by area <span class="area-filter-caret" aria-hidden="true">&#9662;</span>
+    </button>
+    <span id="area-filter-chips" class="area-filter-chips"></span>
+    <button type="button" id="area-filter-clear" class="area-filter-clear" hidden>clear</button>
+    <div id="area-filter-menu" class="area-filter-menu" role="group" aria-label="Filter by area" hidden>
+        {%- for area in site.data.areas.areas -%}
+            {%- assign n = 0 -%}
+            {%- for p in site.databases -%}
+                {%- if p.area contains area -%}{%- assign n = n | plus: 1 -%}{%- endif -%}
+            {%- endfor -%}
+            {%- if n > 0 -%}
+            <label class="area-filter-opt">
+                <input type="checkbox" value="{{ area }}">
+                <span class="area-filter-name">{{ area }}</span>
+                <span class="area-filter-cnt">{{ n }}</span>
+            </label>
+            {%- endif -%}
+        {%- endfor -%}
+    </div>
+</div>
+<table id="imdb_table" class="display datatable" data-order-columns="[1]">
     <thead>
         <tr>
             <th data-dt-order="disable">Info</th>
@@ -71,7 +93,7 @@ layout: plain
                         </ul>
                     {%- endif -%}
                 </td>
-                <td>
+                <td data-search="{%- if p.area -%}|{{ p.area | join: '|' }}|{%- endif -%}">
                     {%- if p.area -%}
                        <ul class="area-list">
                        {%- for a in p.area -%}
@@ -98,3 +120,113 @@ layout: plain
         {%- endfor -%}
     </tbody>
 </table>
+
+<script>
+// Custom "filter by area" control for the index table (issue #86).
+// Areas are multi-valued, so each row's Area cell carries a delimited
+// data-search value ("|area one|area two|"); we filter the Area column with a
+// regex that matches any selected area between pipes.
+//
+// NB: the minimal-mistakes theme bundles its own jQuery which replaces the one
+// loaded in head/custom.html, so DataTables is only reachable via the global
+// `DataTable` (as in custom.html), not $.fn.dataTable. Hence: plain DOM + the
+// global constructor, no jQuery dependency.
+(function () {
+    function init() {
+        var AREA_COL = 4; // Info, Ascii Name, Name, References, Area, Tags, Description
+        var tableEl = document.getElementById('imdb_table');
+        if (!tableEl || typeof DataTable === 'undefined') { return; }
+        // Retrieve (never create) the instance custom.html builds. custom.html
+        // initialises on jQuery's async ready, which runs after this native
+        // DOMContentLoaded handler, so we must not `new DataTable` it ourselves
+        // (that would win the race and drop custom.html's paging/search config).
+        var table = null;
+        function getTable() {
+            if (!table && DataTable.isDataTable(tableEl)) { table = new DataTable(tableEl); }
+            return table;
+        }
+
+        var filter = document.getElementById('area-filter');
+        var toggle = document.getElementById('area-filter-toggle');
+        var menu   = document.getElementById('area-filter-menu');
+        var chips  = document.getElementById('area-filter-chips');
+        var clear  = document.getElementById('area-filter-clear');
+
+        function escapeRegExp(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+        function selectedAreas() {
+            return Array.prototype.slice.call(menu.querySelectorAll('input:checked'))
+                .map(function (c) { return c.value; });
+        }
+
+        function renderChips(areas) {
+            chips.textContent = '';
+            areas.forEach(function (a) {
+                var chip = document.createElement('button');
+                chip.type = 'button';
+                chip.className = 'area-filter-chip';
+                chip.setAttribute('data-area', a);
+                chip.textContent = a;
+                var x = document.createElement('span');
+                x.className = 'area-filter-chip-x';
+                x.setAttribute('aria-hidden', 'true');
+                x.textContent = '×';
+                chip.appendChild(x);
+                chips.appendChild(chip);
+            });
+        }
+
+        function applyFilter() {
+            var t = getTable();
+            if (!t) { return; }
+            var areas = selectedAreas();
+            if (areas.length === 0) {
+                t.column(AREA_COL).search('').draw();
+            } else {
+                var re = '\\|(?:' + areas.map(escapeRegExp).join('|') + ')\\|';
+                t.column(AREA_COL).search(re, true, false).draw();
+            }
+            renderChips(areas);
+            clear.hidden = areas.length === 0;
+            toggle.classList.toggle('has-selection', areas.length > 0);
+        }
+
+        function openMenu(open) {
+            menu.hidden = !open;
+            toggle.setAttribute('aria-expanded', String(open));
+        }
+
+        toggle.addEventListener('click', function (e) {
+            e.stopPropagation();
+            openMenu(menu.hidden);
+        });
+        menu.addEventListener('click', function (e) { e.stopPropagation(); });
+        menu.addEventListener('change', function (e) {
+            if (e.target && e.target.type === 'checkbox') { applyFilter(); }
+        });
+        chips.addEventListener('click', function (e) {
+            var chip = e.target.closest('.area-filter-chip');
+            if (!chip) { return; }
+            var a = chip.getAttribute('data-area');
+            Array.prototype.slice.call(menu.querySelectorAll('input')).forEach(function (c) {
+                if (c.value === a) { c.checked = false; }
+            });
+            applyFilter();
+        });
+        clear.addEventListener('click', function () {
+            Array.prototype.slice.call(menu.querySelectorAll('input:checked'))
+                .forEach(function (c) { c.checked = false; });
+            applyFilter();
+        });
+        document.addEventListener('click', function () { openMenu(false); });
+
+        filter.hidden = false; // reveal now that behaviour is wired up
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();
+</script>

--- a/index.md
+++ b/index.md
@@ -2,12 +2,12 @@
 layout: plain
 ---
 <h1 class="smallcaps" id="imdb_title">Index of Mathematical DataBases</h1>
-<div id="area-filter" class="area-filter" hidden>
+<!-- Area filter (issue #86). JS moves #area-filter-control next to the DataTables
+     search box and #area-filter-chips-row onto its own row below them. -->
+<div id="area-filter-control" class="area-filter-control" hidden>
     <button type="button" id="area-filter-toggle" class="area-filter-toggle" aria-expanded="false" aria-controls="area-filter-menu">
         Filter by area <span class="area-filter-caret" aria-hidden="true">&#9662;</span>
     </button>
-    <span id="area-filter-chips" class="area-filter-chips"></span>
-    <button type="button" id="area-filter-clear" class="area-filter-clear" hidden>clear</button>
     <div id="area-filter-menu" class="area-filter-menu" role="group" aria-label="Filter by area" hidden>
         {%- for area in site.data.areas.areas -%}
             {%- assign n = 0 -%}
@@ -15,7 +15,7 @@ layout: plain
                 {%- if p.area contains area -%}{%- assign n = n | plus: 1 -%}{%- endif -%}
             {%- endfor -%}
             {%- if n > 0 -%}
-            <label class="area-filter-opt">
+            <label class="area-filter-opt" data-count="{{ n }}">
                 <input type="checkbox" value="{{ area }}">
                 <span class="area-filter-name">{{ area }}</span>
                 <span class="area-filter-cnt">{{ n }}</span>
@@ -23,6 +23,10 @@ layout: plain
             {%- endif -%}
         {%- endfor -%}
     </div>
+</div>
+<div id="area-filter-chips-row" class="area-filter-chips-row" hidden>
+    <span id="area-filter-chips" class="area-filter-chips"></span>
+    <button type="button" id="area-filter-clear" class="area-filter-clear" hidden>clear</button>
 </div>
 <table id="imdb_table" class="display datatable" data-order-columns="[1]">
     <thead>
@@ -132,101 +136,136 @@ layout: plain
 // `DataTable` (as in custom.html), not $.fn.dataTable. Hence: plain DOM + the
 // global constructor, no jQuery dependency.
 (function () {
-    function init() {
-        var AREA_COL = 4; // Info, Ascii Name, Name, References, Area, Tags, Description
+    var STORAGE_KEY = 'mathbases:areaFilter';
+    var AREA_COL = 4; // Info, Ascii Name, Name, References, Area, Tags, Description
+
+    function ready(fn) {
+        if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', fn); }
+        else { fn(); }
+    }
+
+    ready(function () {
         var tableEl = document.getElementById('imdb_table');
-        if (!tableEl || typeof DataTable === 'undefined') { return; }
-        // Retrieve (never create) the instance custom.html builds. custom.html
-        // initialises on jQuery's async ready, which runs after this native
-        // DOMContentLoaded handler, so we must not `new DataTable` it ourselves
-        // (that would win the race and drop custom.html's paging/search config).
-        var table = null;
-        function getTable() {
-            if (!table && DataTable.isDataTable(tableEl)) { table = new DataTable(tableEl); }
-            return table;
-        }
+        var control = document.getElementById('area-filter-control');
+        if (!tableEl || !control || typeof DataTable === 'undefined') { return; }
 
-        var filter = document.getElementById('area-filter');
-        var toggle = document.getElementById('area-filter-toggle');
-        var menu   = document.getElementById('area-filter-menu');
-        var chips  = document.getElementById('area-filter-chips');
-        var clear  = document.getElementById('area-filter-clear');
+        // custom.html builds the DataTable on jQuery's async ready, which runs
+        // after this handler, so poll until it exists, then only ever RETRIEVE
+        // it (creating it here would win the race and drop custom.html's config).
+        var tries = 0;
+        (function whenReady() {
+            if (DataTable.isDataTable(tableEl)) { setup(new DataTable(tableEl)); }
+            else if (tries++ < 200) { setTimeout(whenReady, 30); } // setTimeout, not rAF: rAF is paused in background tabs
+        })();
 
-        function escapeRegExp(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+        function setup(table) {
+            var toggle   = document.getElementById('area-filter-toggle');
+            var menu     = document.getElementById('area-filter-menu');
+            var chipsRow = document.getElementById('area-filter-chips-row');
+            var chips    = document.getElementById('area-filter-chips');
+            var clear    = document.getElementById('area-filter-clear');
+            var wrapper  = tableEl.closest('.dataTables_wrapper');
+            var search   = wrapper ? wrapper.querySelector('.dataTables_filter') : null;
 
-        function selectedAreas() {
-            return Array.prototype.slice.call(menu.querySelectorAll('input:checked'))
-                .map(function (c) { return c.value; });
-        }
+            // Order options by frequency (desc), then name (asc).
+            Array.prototype.slice.call(menu.querySelectorAll('.area-filter-opt'))
+                .sort(function (a, b) {
+                    var d = (+b.getAttribute('data-count')) - (+a.getAttribute('data-count'));
+                    return d || a.querySelector('.area-filter-name').textContent
+                        .localeCompare(b.querySelector('.area-filter-name').textContent);
+                })
+                .forEach(function (o) { menu.appendChild(o); });
 
-        function renderChips(areas) {
-            chips.textContent = '';
-            areas.forEach(function (a) {
-                var chip = document.createElement('button');
-                chip.type = 'button';
-                chip.className = 'area-filter-chip';
-                chip.setAttribute('data-area', a);
-                chip.textContent = a;
-                var x = document.createElement('span');
-                x.className = 'area-filter-chip-x';
-                x.setAttribute('aria-hidden', 'true');
-                x.textContent = '×';
-                chip.appendChild(x);
-                chips.appendChild(chip);
-            });
-        }
-
-        function applyFilter() {
-            var t = getTable();
-            if (!t) { return; }
-            var areas = selectedAreas();
-            if (areas.length === 0) {
-                t.column(AREA_COL).search('').draw();
-            } else {
-                var re = '\\|(?:' + areas.map(escapeRegExp).join('|') + ')\\|';
-                t.column(AREA_COL).search(re, true, false).draw();
+            // Place the control just left of the search box in a shared toolbar,
+            // with the selected-area chips on their own row just below.
+            if (search) {
+                var toolbar = document.createElement('div');
+                toolbar.className = 'index-toolbar';
+                search.parentNode.insertBefore(toolbar, search);
+                toolbar.appendChild(control);
+                toolbar.appendChild(search);
+                toolbar.parentNode.insertBefore(chipsRow, toolbar.nextSibling);
             }
-            renderChips(areas);
-            clear.hidden = areas.length === 0;
-            toggle.classList.toggle('has-selection', areas.length > 0);
-        }
 
-        function openMenu(open) {
-            menu.hidden = !open;
-            toggle.setAttribute('aria-expanded', String(open));
-        }
+            function escapeRegExp(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+            function boxes() { return Array.prototype.slice.call(menu.querySelectorAll('input[type=checkbox]')); }
+            function selectedAreas() {
+                return boxes().filter(function (c) { return c.checked; }).map(function (c) { return c.value; });
+            }
 
-        toggle.addEventListener('click', function (e) {
-            e.stopPropagation();
-            openMenu(menu.hidden);
-        });
-        menu.addEventListener('click', function (e) { e.stopPropagation(); });
-        menu.addEventListener('change', function (e) {
-            if (e.target && e.target.type === 'checkbox') { applyFilter(); }
-        });
-        chips.addEventListener('click', function (e) {
-            var chip = e.target.closest('.area-filter-chip');
-            if (!chip) { return; }
-            var a = chip.getAttribute('data-area');
-            Array.prototype.slice.call(menu.querySelectorAll('input')).forEach(function (c) {
-                if (c.value === a) { c.checked = false; }
+            function renderChips(areas) {
+                chips.textContent = '';
+                areas.forEach(function (a) {
+                    var chip = document.createElement('button');
+                    chip.type = 'button';
+                    chip.className = 'area-filter-chip';
+                    chip.setAttribute('data-area', a);
+                    chip.textContent = a;
+                    var x = document.createElement('span');
+                    x.className = 'area-filter-chip-x';
+                    x.setAttribute('aria-hidden', 'true');
+                    x.textContent = '×';
+                    chip.appendChild(x);
+                    chips.appendChild(chip);
+                });
+            }
+
+            function save(areas) {
+                try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(areas)); } catch (e) {}
+            }
+            function load() {
+                try { return JSON.parse(window.localStorage.getItem(STORAGE_KEY)) || []; } catch (e) { return []; }
+            }
+
+            function applyFilter(persist) {
+                var areas = selectedAreas();
+                if (areas.length === 0) {
+                    table.column(AREA_COL).search('').draw();
+                } else {
+                    var re = '\\|(?:' + areas.map(escapeRegExp).join('|') + ')\\|';
+                    table.column(AREA_COL).search(re, true, false).draw();
+                }
+                renderChips(areas);
+                clear.hidden = areas.length === 0;
+                chipsRow.hidden = areas.length === 0;
+                toggle.classList.toggle('has-selection', areas.length > 0);
+                if (persist !== false) { save(areas); }
+            }
+
+            function openMenu(open) {
+                menu.hidden = !open;
+                toggle.setAttribute('aria-expanded', String(open));
+            }
+
+            toggle.addEventListener('click', function (e) { e.stopPropagation(); openMenu(menu.hidden); });
+            menu.addEventListener('click', function (e) { e.stopPropagation(); });
+            menu.addEventListener('change', function (e) {
+                if (e.target && e.target.type === 'checkbox') { applyFilter(); }
             });
-            applyFilter();
-        });
-        clear.addEventListener('click', function () {
-            Array.prototype.slice.call(menu.querySelectorAll('input:checked'))
-                .forEach(function (c) { c.checked = false; });
-            applyFilter();
-        });
-        document.addEventListener('click', function () { openMenu(false); });
+            chips.addEventListener('click', function (e) {
+                var chip = e.target.closest('.area-filter-chip');
+                if (!chip) { return; }
+                var a = chip.getAttribute('data-area');
+                boxes().forEach(function (c) { if (c.value === a) { c.checked = false; } });
+                applyFilter();
+            });
+            clear.addEventListener('click', function () {
+                boxes().forEach(function (c) { c.checked = false; });
+                applyFilter();
+            });
+            document.addEventListener('click', function () { openMenu(false); });
 
-        filter.hidden = false; // reveal now that behaviour is wired up
-    }
+            // Restore the persisted selection, then reflect it without re-saving.
+            var saved = load();
+            if (saved.length) {
+                var set = {};
+                saved.forEach(function (a) { set[a] = true; });
+                boxes().forEach(function (c) { if (set[c.value]) { c.checked = true; } });
+            }
+            applyFilter(false);
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
+            control.hidden = false; // reveal now that it's wired up and placed
+        }
+    });
 })();
 </script>


### PR DESCRIPTION
Closes #86.

Adds a lightweight **"Filter by area"** control above the index table. Of the two options in the issue, this is the "custom controls + `column().search()`" approach (no SearchPanes/Select extensions, no new libraries).

## How it works

- Clicking **Filter by area** opens a checklist of the areas actually in use, each with a per-database count. Selected areas show as removable chips; a **clear** link resets them.
- The table filters to databases in **any** selected area (OR). Because a database can belong to several areas, each row's Area cell now carries a delimited `data-search` value (`"|area one|area two|"`), and the filter drives the DataTables Area-column search with a regex matching any selected area between pipes — so multi-area rows stay correct.

## Notes for reviewers

- The script uses plain DOM + the **global `DataTable`** (as `custom.html` does), not `$.fn.dataTable`: the minimal-mistakes theme bundles its own jQuery that replaces the one `custom.html` loads, leaving DataTables reachable only via the global. It also only ever *retrieves* the instance `custom.html` creates (never initialises it), to avoid racing that init and dropping its paging/search config.
- Progressive enhancement: the control is `hidden` until the script wires it up.
- Only `index.md` and `custom.css` change; other tables/pages are untouched.

## Verified in a browser (local build)

- number theory: 169 → 48 rows, **zero** visible rows missing number theory (multi-area rows correct)
- OR union: number theory ∪ combinatorics = 109 rows, no violations
- chip removal re-unchecks the box; clear restores all rows and hides the clear link
- menu closes on outside-click, stays open on inside-click
- existing DataTable search/sort/no-paging preserved; responsive 2-col desktop / 1-col mobile

Screenshot (number theory applied):

Filter chip + gold active button, table filtered to number-theory databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
