### PR TITLE
Mark two offline databases as no longer accessible (#45, #105)

### DIFF
--- a/_databases/combinatorial-catalogues.md
+++ b/_databases/combinatorial-catalogues.md
@@ -7,6 +7,7 @@ location: http://staffhome.ecm.uwa.edu.au/~00013890/data.html
 title: Combinatorial Catalogues
 area:
 - combinatorics
+accessible: false
 
 ---
 

--- a/_databases/number-fields-jr.md
+++ b/_databases/number-fields-jr.md
@@ -14,7 +14,8 @@ tags:
 - number fields
 title: Database of Number Fields
 searchable: true
+accessible: false
 
 ---
 
-An updated version of this database is available within the LMFDB at https://www.lmfdb.org/NumberField/
+This database is offline indefinitely. It may return in the future, but there is no timeline. Most of its number fields are available within the LMFDB at https://www.lmfdb.org/NumberField/


### PR DESCRIPTION
Triage of the three dead-link issues. I live-checked every URL involved.

## Fixed (marked `accessible: false` → the index shows "(no longer online)")

- **`combinatorial-catalogues`** (#45, #70) — its host `staffhome.ecm.uwa.edu.au` no longer resolves (DNS gone).
- **`number-fields-jr`** (#105) — the Jones-Roberts number field DB is closed indefinitely; the site's own page confirms it ("closed indefinitely… can be found in the LMFDB"), matching John Jones' email. Also updated the body note to say it's offline and point to the LMFDB.

## Checked, no change needed

- **`combinatorial-data-iw`** (#70) — **live again** (200, real content); it appears to have recovered since #70 was filed.
- **`graphlopedia`, `planar-hypohamiltonian-graphs`, `simple-k-angulations`** (#70) — still 404, and already marked `accessible: false`.

## Verified

Local build: both newly-marked entries now render as "*Title* (no longer online)" in the index.

Closes #45. Closes #105.

For #70, all the specific dead links it lists are now resolved, but it also asks for **broken-link-detection infrastructure** and **dataset-preservation** — larger efforts I've left as future work, so I haven't auto-closed it. (The "report a problem" button idea from #45 was already being spun off into its own issue per that thread.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
