### PR TITLE
Redesign the dataset homepage layout

### DIFF
--- a/_includes/thousands.html
+++ b/_includes/thousands.html
@@ -1,0 +1,8 @@
+{%- comment -%}Render include.n with thousands separators (Liquid has no number formatting).{%- endcomment -%}
+{%- assign _digits = include.n | append: '' | split: '' -%}
+{%- assign _len = _digits | size -%}
+{%- for _d in _digits -%}
+{%- assign _rem = _len | minus: forloop.index0 | modulo: 3 -%}
+{%- if forloop.index0 != 0 and _rem == 0 %},{% endif -%}
+{{- _d -}}
+{%- endfor -%}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -2,35 +2,113 @@
 layout: single
 ---
 
-<p>
-  <a href="{{ page.location }}">dataset website
-    <i class="fas fa-external-link-alt" title="link to website for {{ page.name }}"></i>
-  </a>
-{%- if page.code_location -%}
-  {%- if page.code_location.first -%}
-    , code repositories ({%- for c in page.code_location -%}<a href="{{ c }}">{{ forloop.index }} <i class="fas fa-external-link-alt" title="link to code repository {{ forloop.index }} for {{ page.name }}"></i></a>{%- endfor -%})
-  {%- else -%}
-  , <a href="{{ page.code_location }}">code repository
-    <i class="fas fa-external-link-alt" title="link to code repository for {{ page.name }}"></i>
-  </a>
-  {%- endif -%}
-{%- endif -%}
-</p>
+{%- comment -%}
+  Dataset homepage. Surfaces the fields documented in template.md; every block is
+  conditional so sparse entries stay clean. The lead and byline span the top; a
+  right-hand "at a glance" card holds the access links, key facts and badges, and
+  the description flows beside it.
+{%- endcomment -%}
+
+{%- if page.short_description -%}<p class="ds-lead">{{ page.short_description }}</p>{%- endif -%}
+
 {%- if page.authors.size > 0 -%}
-  <ul class="authors-list">
-  {%- for a in page.authors -%}
-    <li>
-      {%- if a.homepage -%}
-        <a href="{{ a.homepage }}">{{ a.name }} <i class="fas fa-external-link-alt" title="link to homepage for {{ a.name }}"></i></a>
-      {%- else -%}
-        {{ a.name }}
-      {%- endif -%}
-      {%- if a.orcid -%}
-        (<a href="{{ a.orcid }}">Orcid for {{ a.name }} <i class="fab fa-orcid" title="link to ORCID for {{ a.name }}"></i></a>)
-      {%- endif -%}
-    </li>
-  {%- endfor -%}
-  </ul>
+  <p class="ds-byline">
+    {%- for a in page.authors -%}
+      {%- if a.homepage -%}<a href="{{ a.homepage }}">{{ a.name }}</a>{%- else -%}{{ a.name | default: a }}{%- endif -%}
+      {%- if a.orcid %}&#8202;<a class="ds-orcid" href="{{ a.orcid }}" title="ORCID record for {{ a.name }}"><i class="fab fa-orcid" aria-hidden="true"></i></a>{% endif -%}
+      {%- if a.email %}&#8202;<a href="mailto:{{ a.email }}" title="email {{ a.name }}"><i class="fas fa-envelope" aria-hidden="true"></i></a>{% endif -%}
+      {%- unless forloop.last %}, {% endunless -%}
+    {%- endfor -%}
+  </p>
 {%- endif -%}
 
+<aside class="ds-card">
+  <div class="ds-access">
+    {%- if page.accessible == false -%}
+      <p class="ds-offline"><i class="fas fa-fw fa-circle-xmark" aria-hidden="true"></i> No longer online</p>
+      {%- if page.location -%}<p class="ds-access-note">was <a href="{{ page.location }}" rel="nofollow">{{ page.location }}</a></p>{%- endif -%}
+    {%- elsif page.location -%}
+      <a class="ds-visit" href="{{ page.location }}">Visit database <i class="fas fa-external-link-alt" aria-hidden="true"></i></a>
+      {%- if page.searchable -%}<p class="ds-access-note"><i class="fas fa-fw fa-magnifying-glass" aria-hidden="true"></i> searchable online</p>{%- endif -%}
+    {%- endif -%}
+    {%- if page.code_location -%}
+      {%- if page.code_location.first -%}
+        {%- for c in page.code_location -%}<p class="ds-access-note"><a href="{{ c }}"><i class="fas fa-fw fa-code" aria-hidden="true"></i> source code{% if page.code_location.size > 1 %} ({{ forloop.index }}){% endif %}</a></p>{%- endfor -%}
+      {%- else -%}
+        <p class="ds-access-note"><a href="{{ page.code_location }}"><i class="fas fa-fw fa-code" aria-hidden="true"></i> source code</a></p>
+      {%- endif -%}
+    {%- endif -%}
+    {%- if page.contact_email -%}
+      <p class="ds-access-note"><a href="mailto:{{ page.contact_email }}"><i class="fas fa-fw fa-envelope" aria-hidden="true"></i> contact</a></p>
+    {%- endif -%}
+  </div>
+
+  <dl class="ds-facts">
+    {%- if page.area.size > 0 -%}
+      <dt>{% if page.area.size == 1 %}Area{% else %}Areas{% endif %}</dt>
+      <dd class="ds-chips">{% for a in page.area %}<span class="ds-chip">{{ a }}</span>{% endfor %}</dd>
+    {%- endif -%}
+    {%- if page.tags.size > 0 -%}
+      <dt>Tags</dt>
+      <dd class="ds-chips">{% for t in page.tags %}<span class="ds-chip ds-chip--tag">{{ t }}</span>{% endfor %}</dd>
+    {%- endif -%}
+    {%- if page.num_objects -%}<dt>Objects</dt><dd>{% include thousands.html n=page.num_objects %}</dd>{%- endif -%}
+    {%- if page.num_datasets -%}<dt>Sub-datasets</dt><dd>{{ page.num_datasets }}</dd>{%- endif -%}
+    {%- if page.size -%}
+      <dt>Size</dt>
+      <dd>
+        {%- assign b = page.size -%}
+        {%- if b >= 1000000000000 -%}{{ b | divided_by: 1000000000000.0 | round: 2 }} TB
+        {%- elsif b >= 1000000000 -%}{{ b | divided_by: 1000000000.0 | round: 2 }} GB
+        {%- elsif b >= 1000000 -%}{{ b | divided_by: 1000000.0 | round: 1 }} MB
+        {%- elsif b >= 1000 -%}{{ b | divided_by: 1000.0 | round: 1 }} KB
+        {%- else -%}{{ b }} bytes{%- endif -%}
+        {%- if page.is_compressed %} (compressed){% endif -%}
+      </dd>
+    {%- endif -%}
+    {%- if page.start_date or page.end_date -%}
+      <dt>Active</dt>
+      <dd>{% if page.start_date %}{{ page.start_date }}{% else %}?{% endif %}{% if page.end_date %}&ndash;{{ page.end_date }}{% elsif page.start_date %}&ndash;present{% endif %}</dd>
+    {%- endif -%}
+    {%- assign ncontrib = page.num_contributors | default: page.contributors -%}
+    {%- if ncontrib -%}<dt>Contributors</dt><dd>{% include thousands.html n=ncontrib %}</dd>{%- endif -%}
+    {%- if page.license -%}<dt>License</dt><dd>{{ page.license }}</dd>{%- endif -%}
+    {%- if page.parent_dataset -%}<dt>Part of</dt><dd><a href="/d/{{ page.parent_dataset }}">{{ page.parent_dataset }}</a></dd>{%- endif -%}
+  </dl>
+
+  {%- if page.badges.size > 0 -%}
+    <div class="ds-badges" title="dataset badges">
+      {%- for badge in page.badges -%}<span class="ds-badge">{{ badge | replace: '_', ' ' }}</span>{%- endfor -%}
+    </div>
+  {%- endif -%}
+</aside>
+
+{%- if page.completeness -%}<p class="ds-completeness"><strong>Completeness.</strong> {{ page.completeness }}</p>{%- endif -%}
+
 {{ content }}
+
+{%- if page.references.size > 0 -%}
+  <section class="ds-section">
+    <h2 class="ds-h">References</h2>
+    <ul class="ds-references">
+      {%- for ref in page.references -%}
+        {%- for pair in ref -%}
+          {%- assign k = pair[0] -%}
+          {%- assign v = pair[1] -%}
+          <li>
+            {%- case k -%}
+              {%- when 'doi' -%}<a href="https://doi.org/{{ v }}">doi:{{ v }}</a>
+              {%- when 'arxiv' -%}<a href="https://arxiv.org/abs/{{ v }}">arXiv:{{ v }}</a>
+              {%- when 'eprint' -%}<a href="https://eprint.iacr.org/{{ v }}">ePrint {{ v }}</a>
+              {%- when 'mr' -%}<a href="https://mathscinet.ams.org/mathscinet-getitem?mr={{ v }}">MR {{ v }}</a>
+              {%- when 'isbn' -%}ISBN&nbsp;<a href="https://www.google.com/search?tbm=bks&q=isbn:{{ v }}">{{ v }}</a>
+              {%- when 'issn' -%}ISSN&nbsp;<a href="https://portal.issn.org/resource/ISSN/{{ v }}">{{ v }}</a>
+              {%- when 'url', 'web', 'blog' -%}<a href="{{ v }}">{{ v }}</a>
+              {%- else -%}{{ v }}
+            {%- endcase -%}
+          </li>
+        {%- endfor -%}
+      {%- endfor -%}
+    </ul>
+  </section>
+{%- endif -%}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -4,58 +4,13 @@ layout: single
 
 {%- comment -%}
   Dataset homepage. Surfaces the fields documented in template.md; every block is
-  conditional so sparse entries stay clean. Two columns on wide screens: the
-  description on the left, an "at a glance" card pinned to the right (they stack
-  on narrow screens).
+  conditional so sparse entries stay clean. Two columns on wide screens: an "at a
+  glance" card pinned to the right, the description on the left (they stack on
+  narrow screens). The card is first in the DOM so it degrades to the top of the
+  page (rather than the bottom) if the flex styles are ever unavailable.
 {%- endcomment -%}
 
 <div class="ds-body">
-<div class="ds-main">
-
-{%- if page.short_description -%}<p class="ds-lead">{{ page.short_description }}</p>{%- endif -%}
-
-{%- if page.authors.size > 0 -%}
-  <p class="ds-byline">
-    {%- for a in page.authors -%}
-      {%- if a.homepage -%}<a href="{{ a.homepage }}">{{ a.name }}</a>{%- else -%}{{ a.name | default: a }}{%- endif -%}
-      {%- if a.orcid %}&#8202;<a class="ds-orcid" href="{{ a.orcid }}" title="ORCID record for {{ a.name }}"><i class="fab fa-orcid" aria-hidden="true"></i></a>{% endif -%}
-      {%- if a.email %}&#8202;<a href="mailto:{{ a.email }}" title="email {{ a.name }}"><i class="fas fa-envelope" aria-hidden="true"></i></a>{% endif -%}
-      {%- unless forloop.last %}, {% endunless -%}
-    {%- endfor -%}
-  </p>
-{%- endif -%}
-
-{%- if page.completeness -%}<p class="ds-completeness"><strong>Completeness.</strong> {{ page.completeness }}</p>{%- endif -%}
-
-{{ content }}
-
-{%- if page.references.size > 0 -%}
-  <section class="ds-section">
-    <h2 class="ds-h">References</h2>
-    <ul class="ds-references">
-      {%- for ref in page.references -%}
-        {%- for pair in ref -%}
-          {%- assign k = pair[0] -%}
-          {%- assign v = pair[1] -%}
-          <li>
-            {%- case k -%}
-              {%- when 'doi' -%}<a href="https://doi.org/{{ v }}">doi:{{ v }}</a>
-              {%- when 'arxiv' -%}<a href="https://arxiv.org/abs/{{ v }}">arXiv:{{ v }}</a>
-              {%- when 'eprint' -%}<a href="https://eprint.iacr.org/{{ v }}">ePrint {{ v }}</a>
-              {%- when 'mr' -%}<a href="https://mathscinet.ams.org/mathscinet-getitem?mr={{ v }}">MR {{ v }}</a>
-              {%- when 'isbn' -%}ISBN&nbsp;<a href="https://www.google.com/search?tbm=bks&q=isbn:{{ v }}">{{ v }}</a>
-              {%- when 'issn' -%}ISSN&nbsp;<a href="https://portal.issn.org/resource/ISSN/{{ v }}">{{ v }}</a>
-              {%- when 'url', 'web', 'blog' -%}<a href="{{ v }}">{{ v }}</a>
-              {%- else -%}{{ v }}
-            {%- endcase -%}
-          </li>
-        {%- endfor -%}
-      {%- endfor -%}
-    </ul>
-  </section>
-{%- endif -%}
-
-</div>{%- comment -%} /.ds-main {%- endcomment -%}
 
 <aside class="ds-card">
   <div class="ds-access">
@@ -117,5 +72,52 @@ layout: single
     </div>
   {%- endif -%}
 </aside>
+
+<div class="ds-main">
+
+{%- if page.short_description -%}<p class="ds-lead">{{ page.short_description }}</p>{%- endif -%}
+
+{%- if page.authors.size > 0 -%}
+  <p class="ds-byline">
+    {%- for a in page.authors -%}
+      {%- if a.homepage -%}<a href="{{ a.homepage }}">{{ a.name }}</a>{%- else -%}{{ a.name | default: a }}{%- endif -%}
+      {%- if a.orcid %}&#8202;<a class="ds-orcid" href="{{ a.orcid }}" title="ORCID record for {{ a.name }}"><i class="fab fa-orcid" aria-hidden="true"></i></a>{% endif -%}
+      {%- if a.email %}&#8202;<a href="mailto:{{ a.email }}" title="email {{ a.name }}"><i class="fas fa-envelope" aria-hidden="true"></i></a>{% endif -%}
+      {%- unless forloop.last %}, {% endunless -%}
+    {%- endfor -%}
+  </p>
+{%- endif -%}
+
+{%- if page.completeness -%}<p class="ds-completeness"><strong>Completeness.</strong> {{ page.completeness }}</p>{%- endif -%}
+
+{{ content }}
+
+{%- if page.references.size > 0 -%}
+  <section class="ds-section">
+    <h2 class="ds-h">References</h2>
+    <ul class="ds-references">
+      {%- for ref in page.references -%}
+        {%- for pair in ref -%}
+          {%- assign k = pair[0] -%}
+          {%- assign v = pair[1] -%}
+          <li>
+            {%- case k -%}
+              {%- when 'doi' -%}<a href="https://doi.org/{{ v }}">doi:{{ v }}</a>
+              {%- when 'arxiv' -%}<a href="https://arxiv.org/abs/{{ v }}">arXiv:{{ v }}</a>
+              {%- when 'eprint' -%}<a href="https://eprint.iacr.org/{{ v }}">ePrint {{ v }}</a>
+              {%- when 'mr' -%}<a href="https://mathscinet.ams.org/mathscinet-getitem?mr={{ v }}">MR {{ v }}</a>
+              {%- when 'isbn' -%}ISBN&nbsp;<a href="https://www.google.com/search?tbm=bks&q=isbn:{{ v }}">{{ v }}</a>
+              {%- when 'issn' -%}ISSN&nbsp;<a href="https://portal.issn.org/resource/ISSN/{{ v }}">{{ v }}</a>
+              {%- when 'url', 'web', 'blog' -%}<a href="{{ v }}">{{ v }}</a>
+              {%- else -%}{{ v }}
+            {%- endcase -%}
+          </li>
+        {%- endfor -%}
+      {%- endfor -%}
+    </ul>
+  </section>
+{%- endif -%}
+
+</div>{%- comment -%} /.ds-main {%- endcomment -%}
 
 </div>{%- comment -%} /.ds-body {%- endcomment -%}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -4,10 +4,13 @@ layout: single
 
 {%- comment -%}
   Dataset homepage. Surfaces the fields documented in template.md; every block is
-  conditional so sparse entries stay clean. The lead and byline span the top; a
-  right-hand "at a glance" card holds the access links, key facts and badges, and
-  the description flows beside it.
+  conditional so sparse entries stay clean. Two columns on wide screens: the
+  description on the left, an "at a glance" card pinned to the right (they stack
+  on narrow screens).
 {%- endcomment -%}
+
+<div class="ds-body">
+<div class="ds-main">
 
 {%- if page.short_description -%}<p class="ds-lead">{{ page.short_description }}</p>{%- endif -%}
 
@@ -21,6 +24,38 @@ layout: single
     {%- endfor -%}
   </p>
 {%- endif -%}
+
+{%- if page.completeness -%}<p class="ds-completeness"><strong>Completeness.</strong> {{ page.completeness }}</p>{%- endif -%}
+
+{{ content }}
+
+{%- if page.references.size > 0 -%}
+  <section class="ds-section">
+    <h2 class="ds-h">References</h2>
+    <ul class="ds-references">
+      {%- for ref in page.references -%}
+        {%- for pair in ref -%}
+          {%- assign k = pair[0] -%}
+          {%- assign v = pair[1] -%}
+          <li>
+            {%- case k -%}
+              {%- when 'doi' -%}<a href="https://doi.org/{{ v }}">doi:{{ v }}</a>
+              {%- when 'arxiv' -%}<a href="https://arxiv.org/abs/{{ v }}">arXiv:{{ v }}</a>
+              {%- when 'eprint' -%}<a href="https://eprint.iacr.org/{{ v }}">ePrint {{ v }}</a>
+              {%- when 'mr' -%}<a href="https://mathscinet.ams.org/mathscinet-getitem?mr={{ v }}">MR {{ v }}</a>
+              {%- when 'isbn' -%}ISBN&nbsp;<a href="https://www.google.com/search?tbm=bks&q=isbn:{{ v }}">{{ v }}</a>
+              {%- when 'issn' -%}ISSN&nbsp;<a href="https://portal.issn.org/resource/ISSN/{{ v }}">{{ v }}</a>
+              {%- when 'url', 'web', 'blog' -%}<a href="{{ v }}">{{ v }}</a>
+              {%- else -%}{{ v }}
+            {%- endcase -%}
+          </li>
+        {%- endfor -%}
+      {%- endfor -%}
+    </ul>
+  </section>
+{%- endif -%}
+
+</div>{%- comment -%} /.ds-main {%- endcomment -%}
 
 <aside class="ds-card">
   <div class="ds-access">
@@ -83,32 +118,4 @@ layout: single
   {%- endif -%}
 </aside>
 
-{%- if page.completeness -%}<p class="ds-completeness"><strong>Completeness.</strong> {{ page.completeness }}</p>{%- endif -%}
-
-{{ content }}
-
-{%- if page.references.size > 0 -%}
-  <section class="ds-section">
-    <h2 class="ds-h">References</h2>
-    <ul class="ds-references">
-      {%- for ref in page.references -%}
-        {%- for pair in ref -%}
-          {%- assign k = pair[0] -%}
-          {%- assign v = pair[1] -%}
-          <li>
-            {%- case k -%}
-              {%- when 'doi' -%}<a href="https://doi.org/{{ v }}">doi:{{ v }}</a>
-              {%- when 'arxiv' -%}<a href="https://arxiv.org/abs/{{ v }}">arXiv:{{ v }}</a>
-              {%- when 'eprint' -%}<a href="https://eprint.iacr.org/{{ v }}">ePrint {{ v }}</a>
-              {%- when 'mr' -%}<a href="https://mathscinet.ams.org/mathscinet-getitem?mr={{ v }}">MR {{ v }}</a>
-              {%- when 'isbn' -%}ISBN&nbsp;<a href="https://www.google.com/search?tbm=bks&q=isbn:{{ v }}">{{ v }}</a>
-              {%- when 'issn' -%}ISSN&nbsp;<a href="https://portal.issn.org/resource/ISSN/{{ v }}">{{ v }}</a>
-              {%- when 'url', 'web', 'blog' -%}<a href="{{ v }}">{{ v }}</a>
-              {%- else -%}{{ v }}
-            {%- endcase -%}
-          </li>
-        {%- endfor -%}
-      {%- endfor -%}
-    </ul>
-  </section>
-{%- endif -%}
+</div>{%- comment -%} /.ds-body {%- endcomment -%}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -231,12 +231,13 @@ h1, h2 {
 .ds-byline { margin: 0 0 18px 0; color: #555; }
 .ds-orcid { color: #a6ce39; }
 
-/* "At a glance" card, floated beside the description on wide screens. */
+/* Two columns on wide screens: description left, "at a glance" card pinned right. */
+.ds-body { display: flex; gap: 26px; align-items: flex-start; }
+.ds-main { flex: 1 1 auto; min-width: 0; }
 .ds-card {
-  float: right;
-  width: 310px;
+  flex: 0 0 290px;
+  align-self: flex-start;
   max-width: 100%;
-  margin: 2px 0 18px 26px;
   padding: 14px 16px;
   background: #fffcf7;
   border: 1px solid #0a1045;
@@ -316,7 +317,7 @@ h1, h2 {
   border-radius: 0 3px 3px 0;
 }
 
-.ds-section { clear: right; margin-top: 26px; }
+.ds-section { margin-top: 26px; }
 .ds-h {
   font-size: 1.2em;
   border-bottom: 1px solid #e6dcc9;
@@ -326,6 +327,7 @@ h1, h2 {
 .ds-references { margin: 0 0 0 1.2em; }
 .ds-references li { margin: 4px 0; overflow-wrap: anywhere; }
 
-@media (max-width: 640px) {
-  .ds-card { float: none; width: auto; margin: 0 0 18px 0; }
+@media (max-width: 767px) {
+  .ds-body { flex-direction: column; }
+  .ds-card { flex-basis: auto; order: -1; margin-bottom: 18px; }
 }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -231,11 +231,18 @@ h1, h2 {
 .ds-byline { margin: 0 0 18px 0; color: #555; }
 .ds-orcid { color: #a6ce39; }
 
-/* Two columns on wide screens: description left, "at a glance" card pinned right. */
-.ds-body { display: flex; gap: 26px; align-items: flex-start; }
-.ds-main { flex: 1 1 auto; min-width: 0; }
+/* Reclaim the theme's empty right-sidebar gutter on dataset pages, so the card
+   can sit at the true right edge with room for the description beside it. */
+.layout--dataset .page { padding-right: 0; }
+
+/* Two columns on wide screens: description left, "at a glance" card pinned right.
+   The card comes first in the DOM (so it degrades to the top, not the bottom),
+   and `order` puts it on the right. */
+.ds-body { display: flex; gap: 30px; align-items: flex-start; }
+.ds-main { flex: 1 1 auto; min-width: 0; order: 1; }
 .ds-card {
-  flex: 0 0 290px;
+  flex: 0 0 300px;
+  order: 2;
   align-self: flex-start;
   max-width: 100%;
   padding: 14px 16px;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -220,3 +220,112 @@ h1, h2 {
     right: auto;
   }
 }
+
+/* Dataset homepage layout (dataset.html) */
+.ds-lead {
+  font-size: 1.2em;
+  line-height: 1.5;
+  color: #333;
+  margin: 0 0 6px 0;
+}
+.ds-byline { margin: 0 0 18px 0; color: #555; }
+.ds-orcid { color: #a6ce39; }
+
+/* "At a glance" card, floated beside the description on wide screens. */
+.ds-card {
+  float: right;
+  width: 310px;
+  max-width: 100%;
+  margin: 2px 0 18px 26px;
+  padding: 14px 16px;
+  background: #fffcf7;
+  border: 1px solid #0a1045;
+  border-radius: 6px;
+  box-shadow: 0 2px 10px rgba(10, 16, 69, 0.09);
+  font-size: 0.92em;
+}
+.ds-visit {
+  display: block;
+  text-align: center;
+  padding: 9px 12px;
+  margin: 0 0 8px 0;
+  font-weight: 600;
+  color: #0a1045;
+  background: #ffca76;
+  border: 1px solid #0a1045;
+  border-radius: 4px;
+}
+.ds-visit:hover { background: #FBE6C5; }
+.ds-access-note { margin: 5px 0; }
+.ds-offline {
+  margin: 0 0 4px 0;
+  font-weight: 600;
+  color: #a4243b;
+}
+.ds-offline .fa-fw { color: #a4243b; }
+
+.ds-facts {
+  margin: 12px 0 0 0;
+  padding-top: 10px;
+  border-top: 1px solid #e6dcc9;
+}
+.ds-facts dt {
+  font-size: 0.72em;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a7f6a;
+  margin-top: 9px;
+}
+.ds-facts dt:first-child { margin-top: 0; }
+.ds-facts dd { margin: 1px 0 0 0; }
+
+.ds-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
+.ds-chip {
+  display: inline-block;
+  padding: 1px 9px;
+  font-size: 0.92em;
+  color: #0a1045;
+  background: #FBE6C5;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+.ds-chip--tag { background: #ece6f2; }
+
+.ds-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e6dcc9;
+}
+.ds-badge {
+  padding: 2px 8px;
+  font-size: 0.78em;
+  color: #0a1045;
+  border: 1px solid #b9b09c;
+  border-radius: 3px;
+  text-transform: capitalize;
+}
+
+.ds-completeness {
+  padding: 9px 13px;
+  background: #f4efe6;
+  border-left: 3px solid #ffca76;
+  border-radius: 0 3px 3px 0;
+}
+
+.ds-section { clear: right; margin-top: 26px; }
+.ds-h {
+  font-size: 1.2em;
+  border-bottom: 1px solid #e6dcc9;
+  padding-bottom: 3px;
+  margin-bottom: 10px;
+}
+.ds-references { margin: 0 0 0 1.2em; }
+.ds-references li { margin: 4px 0; overflow-wrap: anywhere; }
+
+@media (max-width: 640px) {
+  .ds-card { float: none; width: auto; margin: 0 0 18px 0; }
+}


### PR DESCRIPTION
The old dataset page showed only the website link, code repos, authors, and the body — most of the ~30 fields in `template.md` never appeared. This reworks the layout to surface them and improve readability.

## Layout

- **Lead** (`short_description`) and an **author byline** (with ORCID/email links) across the top.
- A right-hand **"at a glance" card**:
  - a prominent **Visit database** button — or a red **"No longer online"** notice when `accessible: false` (which the old page ignored);
  - `searchable` / `source code` / `contact` links;
  - a facts list: **areas, tags, objects, sub-datasets, size, active dates, contributors, license, part-of** — plus **badges**.
- A **References** section, formatting each reference by type (`doi`, `arxiv`, `eprint`, `mr`, `isbn`, `issn`, `url`/`web`/`blog`, …).
- A **completeness** note when present.

Every block is conditional, so sparse entries stay clean, and the card stacks full-width on narrow screens.

## Readability details

- Numbers get thousands separators (`2,904,196,308`) via a small `_includes/thousands.html` (Liquid has no number formatting).
- `size` is shown human-readably (`2.07 TB`) with a "(compressed)" note when `is_compressed`.
- Chips for areas/tags/badges; palette matches the site.

## Verified in-browser

Rich (`lmfdb` — desktop + mobile), lead + references (`analytic-number-theory-exponent-database`), offline (`graphlopedia`), sparse/empty-body (`combinatorial-catalogues`), and doi references (`local-fields`). The theme's "Updated:" date still renders.

## Screenshots

`lmfdb` (rich): Visit button, area chips, Objects 2,904,196,308, Size 2.07 TB, Active 2007–present, Contributors 117, badges — with the description flowing beside the card.

## Data issues noticed (out of scope — flagging)

- `graphlopedia` has a **duplicate `authors:` key**; YAML keeps the last one (a single malformed string author), so its 11 real authors are lost. The layout now degrades gracefully, but the data should be fixed.
- `polytopes-derived-from-sporadic` has a **malformed (string) reference** that renders as nothing.
- `badges.yml` is a stub, so badge chips show the humanized key (e.g. "Has license"); populating it would allow nicer labels/tooltips. Also spotted a badge typo `collaboriative` in one entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
