### PR TITLE
Fix malformed authors and reference fields

### DIFF
--- a/_databases/graphlopedia.md
+++ b/_databases/graphlopedia.md
@@ -6,6 +6,7 @@ authors:
 - name: Kimberly Bautista
 - name: Aaron Bode
 - name: Riley Casper
+- name: Sharat Chandra
 - name: Dien Dang
 - name: Nicholas Farn
 - name: Graham Kelley
@@ -18,8 +19,6 @@ area:
 - combinatorics
 tags:
 - graph theory
-authors:
- - Sharat Chandra
 accessible: false
 
 ---

--- a/_databases/polytopes-derived-from-sporadic.md
+++ b/_databases/polytopes-derived-from-sporadic.md
@@ -8,7 +8,7 @@ id: polytopes-derived-from-sporadic
 location: http://www.abstract-polytopes.com/sporpolys/
 num_objects: 6047
 references:
-- doi:10.11575/cdm.v5i2.61945
+- doi: 10.11575/cdm.v5i2.61945
 area:
 - metric geometry
 - group theory


### PR DESCRIPTION
Fixes the two malformed-field data issues flagged in #164.

- **`graphlopedia`** had a **duplicate `authors:` key**. YAML keeps only the last occurrence — a single string author (`Sharat Chandra`) — so the 11 real authors were silently dropped. Merged the two into one list (Sharat Chandra slotted in alphabetically by surname). All **12 authors** now render.
- **`polytopes-derived-from-sporadic`** had `- doi:10.11575/…` with **no space after the colon**, so YAML parsed it as a plain string rather than a `{doi: …}` map and it rendered as nothing. Added the space.

## Verified (local build)

- graphlopedia now renders 12 authors (Bautista, Bode, Casper, Chandra, Dang, Farn, Kelley, Lai, Ranganathan, Trinh, Tsun, Warner).
- The polytopes reference now links to https://doi.org/10.11575/cdm.v5i2.61945 in the index References column.

(Both also benefit the redesigned dataset page in #164 — the byline and References section respectively.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
