### PR TITLE
Add eight requested databases (#106–#136)

### DIFF
--- a/_databases/circulant-weighing-matrices.md
+++ b/_databases/circulant-weighing-matrices.md
@@ -9,6 +9,8 @@ short_description: "Database of existence and nonexistence results for circulant
 authors:
   - name: Daniel M. Gordon
     homepage: "https://www.dmgordon.org/"
+references:
+  - doi: 10.5281/zenodo.10775927
 tags:
   - weighing matrices
   - combinatorial designs

--- a/_databases/coh-modsp.md
+++ b/_databases/coh-modsp.md
@@ -1,0 +1,17 @@
+---
+id: coh-modsp
+location: https://github.com/jonasbergstroem/Cohomology-of-moduli-spaces-of-curves
+title: Cohomology of moduli spaces of curves
+area:
+  - algebraic geometry
+short_description: A compilation of results on the cohomology of moduli spaces of smooth and stable curves.
+authors:
+  - name: Jonas Bergström
+    homepage: https://www.su.se/english/profiles/j/jonab
+start_date: 2024
+tags:
+  - moduli spaces
+  - cohomology
+---
+
+A compilation of results on the cohomology of moduli spaces of smooth and stable curves, drawn together from research in several different sources.

--- a/_databases/difference-sets.md
+++ b/_databases/difference-sets.md
@@ -9,6 +9,8 @@ short_description: Parameter tables and known examples of (v,k,lambda)-differenc
 authors:
   - name: Daniel M. Gordon
     homepage: "https://www.dmgordon.org/"
+references:
+  - doi: 10.5281/zenodo.10775931
 tags:
   - difference sets
   - combinatorial designs

--- a/_databases/galois-group-data.md
+++ b/_databases/galois-group-data.md
@@ -1,0 +1,17 @@
+---
+id: galois-group-data
+location: https://hobbes.la.asu.edu/Groups/
+title: Galois Group Data
+area:
+  - group theory
+  - number theory
+short_description: Data on the transitive permutation groups that arise as Galois groups of number fields.
+authors:
+  - name: John Jones
+    homepage: https://hobbes.la.asu.edu/
+tags:
+  - Galois groups
+  - transitive groups
+---
+
+Tables of the transitive subgroups of the symmetric groups S_n for small n — names, orders, generators and related invariants — as used when they arise as Galois groups of number fields. Much of this data has since been incorporated into the LMFDB, though this remains a standalone resource.

--- a/_databases/is-sike-broken-yet.md
+++ b/_databases/is-sike-broken-yet.md
@@ -1,0 +1,16 @@
+---
+id: is-sike-broken-yet
+location: https://issikebrokenyet.github.io/
+title: Is SIKE broken yet?
+area:
+  - number theory
+  - information theory
+short_description: A catalogue of isogeny-based cryptographic schemes and the known attacks against them.
+code_location: https://github.com/issikebrokenyet/issikebrokenyet.github.io
+tags:
+  - post-quantum cryptography
+  - isogenies
+  - elliptic curves
+---
+
+Tracks the security status of isogeny-based cryptographic schemes — SIDH, SIKE, CSIDH and others — listing the underlying hardness assumptions and the best known classical and quantum attacks against each.

--- a/_databases/low-grd-fields.md
+++ b/_databases/low-grd-fields.md
@@ -1,0 +1,18 @@
+---
+id: low-grd-fields
+location: https://hobbes.la.asu.edu/lowgrd/
+title: Fields with Small Galois Root Discriminant
+area:
+  - number theory
+short_description: Tables of number fields with small Galois root discriminant, organized by Galois group.
+authors:
+  - name: John Jones
+    homepage: https://hobbes.la.asu.edu/
+  - name: David P. Roberts
+    homepage: https://www.davidproberts.net/
+tags:
+  - number fields
+  - root discriminant
+---
+
+Tables of number fields with small Galois root discriminant, organized by Galois group, giving defining polynomials and discriminant data. Not all of these fields appear in the LMFDB.

--- a/_databases/markov-bases.md
+++ b/_databases/markov-bases.md
@@ -1,0 +1,18 @@
+---
+id: markov-bases
+location: https://markov-bases.de/
+title: The Markov Bases Database
+area:
+  - algebraic geometry
+  - statistics
+short_description: A collection of computed Markov bases of the toric ideals arising in algebraic statistics.
+authors:
+  - name: Thomas Kahle
+  - name: Johannes Rauh
+tags:
+  - markov bases
+  - toric ideals
+  - algebraic statistics
+---
+
+A database of Markov bases — generating sets of the toric ideals associated with statistical models, in the sense of Diaconis and Sturmfels. The bases are computed with the software package 4ti2, and normality of the corresponding semigroups is checked with Normaliz.

--- a/_databases/relative-difference-sets.md
+++ b/_databases/relative-difference-sets.md
@@ -1,0 +1,18 @@
+---
+id: relative-difference-sets
+location: https://doi.org/10.5281/zenodo.14735633
+title: Relative Difference Sets
+area:
+  - combinatorics
+short_description: The La Jolla relative difference sets repository — computational data on relative difference sets.
+authors:
+  - name: Daniel M. Gordon
+    homepage: https://www.dmgordon.org/
+references:
+  - arxiv: 2501.14924
+tags:
+  - difference sets
+  - combinatorial designs
+---
+
+The La Jolla Relative Difference Sets Repository: computational tools and tables for constructing and analysing relative difference sets, archived on Zenodo.

--- a/_databases/ries.md
+++ b/_databases/ries.md
@@ -1,0 +1,20 @@
+---
+id: ries
+location: https://thomasahle.com/ries/
+title: RIES
+area:
+  - number theory
+searchable: true
+short_description: An inverse symbolic calculator that finds simple closed-form equations satisfied by a given number.
+authors:
+  - name: Robert Munafo
+    homepage: https://mrob.com/pub/ries/
+  - name: Thomas Ahle
+    homepage: https://thomasahle.com/
+references:
+  - url: https://mrob.com/pub/ries/index.html
+tags:
+  - inverse symbolic calculator
+---
+
+RIES takes a number and searches for simple closed-form equations that the number approximately satisfies — an "inverse symbolic calculator." It was originally written as a command-line program by Robert Munafo; this page provides a web interface by Thomas Ahle.

--- a/_databases/z-cyclic-whist-tournaments.md
+++ b/_databases/z-cyclic-whist-tournaments.md
@@ -1,0 +1,16 @@
+---
+id: z-cyclic-whist-tournaments
+location: https://hobbes.la.asu.edu/whist.html
+title: Z-cyclic Whist Tournaments
+area:
+  - combinatorics
+short_description: Data for constructing Z-cyclic whist tournaments for q² players, q a prime congruent to 3 mod 4.
+authors:
+  - name: John Jones
+    homepage: https://hobbes.la.asu.edu/
+tags:
+  - whist tournaments
+  - combinatorial designs
+---
+
+Computational data enabling the construction of Z-cyclic whist tournaments for q² players, where q is a prime congruent to 3 modulo 4, following the method of Leonard (1996). The data is provided as a downloadable file.


### PR DESCRIPTION
Adds the eight requested databases, one per issue.

| Issue | Entry | Location |
|---|---|---|
| #136 | Cohomology of moduli spaces of curves | github.com/jonasbergstroem/… |
| #133 | The Markov Bases Database | markov-bases.de |
| #126 | RIES (inverse symbolic calculator) | thomasahle.com/ries |
| #113 | Relative Difference Sets (La Jolla repository) | Zenodo |
| #111 | Is SIKE broken yet? | issikebrokenyet.github.io |
| #108 | Z-cyclic Whist Tournaments | hobbes.la.asu.edu/whist.html |
| #107 | Galois Group Data | hobbes.la.asu.edu/Groups |
| #106 | Fields with Small Galois Root Discriminant | hobbes.la.asu.edu/lowgrd |

Metadata (title, authors, area, description) was drawn from each site (and, for #136, the draft in the issue). All `area` values are validated against `_data/areas.yml`.

**#113 specifics:** the `dmgordon.org/rds/` page doesn't exist, so *Relative Difference Sets* points to its Zenodo record and references arXiv:2501.14924. I also added the requested Zenodo archive DOIs to the existing **Difference Sets** and **Circulant Weighing Matrices** entries (Signed Difference Sets already had one).

## Verified (local build)
- All 8 pages build and appear in the index; sort keys regenerated (170 → 178).
- The two edited entries now show their Zenodo DOI.
- Spot-checked rendering in the new dataset layout (e.g. RIES: lead, byline, references, and the at-a-glance card).

## Notes / judgement calls
- **Is SIKE broken yet?** lists no authors (community GitHub project), so the entry has none; area is `number theory` + `information theory` (isogeny-based crypto).
- **RIES** is a query tool rather than an object database, but it was requested; credited to Robert Munafo (original) and Thomas Ahle (web interface).
- **Galois Group Data** notes it's largely subsumed by the LMFDB (per the issue), following the `local-fields` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
